### PR TITLE
cd: update NPM_TOKEN in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ASSOCIATION_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.BESM_NPM_RELEASE_TOKEN }}
         run: |
           cd dist
           yarn --frozen-lockfile


### PR DESCRIPTION
This PR updates the NPM token reference in the GitHub Actions CI/CD workflow to use a dedicated token for the Browser Extension Signing Manager (BESM) instead of the generic association token.

**Changes made:**
- Updated `.github/workflows/main.yml` to reference `BESM_NPM_RELEASE_TOKEN` instead of `ASSOCIATION_NPM_TOKEN` in the release job environment variables

This change ensures that the BESM project uses its own dedicated NPM token for releases, improving security isolation and token management.

### Breaking Changes

None - this is an infrastructure change that doesn't affect the public API or functionality of the library.

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?

---

*Note: No README update is required for this change as it's an internal CI/CD configuration update that doesn't affect end users or the public API.*
